### PR TITLE
add support for CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `capi_machine_info`
   - `capi_machine_status_conditions`
   - `capi_machine_status_phase`
+- initial support for Cluster API cluster
+  - `capi_cluster_info`
+  - `capi_cluster_status_conditions`
+  - `capi_cluster_status_phase`
 - initialize the "empty" app with serviceaccount only
 
 [Unreleased]: https://github.com/giantswarm/{APP-NAME}/tree/main

--- a/helm/cluster-api-monitoring/configuration/capi_cluster.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_cluster.yaml
@@ -1,0 +1,43 @@
+labelsFromPath:
+  name: [metadata, name]
+  cluster: [metadata, name]
+  namespace: [metadata, namespace]
+metrics:
+  - name: status_conditions
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - status
+        labelFromKey: reason
+        labelsFromPath:
+          type: [type]
+  - name: info
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          control_plane_endpoint_host: [spec, controlPlaneEndpoint, host]
+          control_plane_endpoint_port: [spec, controlPlaneEndpoint, port]
+          control_plane_reference_kind: [spec, controlPlaneRef, kind]
+          control_plane_reference_name: [spec, controlPlaneRef, name]
+          infrastructure_reference_kind: [spec, infrastructureRef, kind]
+          infrastructure_reference_name: [spec, infrastructureRef, name]
+  - name: status_phase
+    each:
+      type: StateSet
+      stateSet:
+        path:
+          - status
+          - phase
+        list:
+          - Pending
+          - Provisioning
+          - Provisioned
+          - Deleting
+          - Failed
+          - Unknown
+        labelName: phase

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -69,3 +69,8 @@ monitoredResources:
       kind: Machine
       version: v1beta1
       plural: machines
+    cluster:
+      group: cluster.x-k8s.io
+      kind: Cluster
+      version: v1beta1
+      plural: clusters


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR is based on #3 and only focused on Cluster API `clusters` metrics

> NOTE: beside the examples in the PR, `capi_cluster` metric is now singular - `s/clusters/cluster/g`

- adds support to generate following Cluster API cluster related metrics
  - `capi_clusters_info` 
    e.g.: 
     ```
    capi_clusters_info{cluster="galaxy", container="cluster-api-monitoring", control_plane_endpoint_host="216.119.153.219", control_plane_endpoint_port="216.119.153.219", control_plane_reference_kind="KubeadmControlPlane", control_plane_reference_name="galaxy", endpoint="metrics", exported_namespace="org-giantswarm", infrastructure_reference_kind="OpenStackCluster", infrastructure_reference_name="galaxy", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 1
    capi_clusters_info{cluster="test5", container="cluster-api-monitoring", control_plane_endpoint_host="216.119.153.216", control_plane_endpoint_port="216.119.153.216", control_plane_reference_kind="KubeadmControlPlane", control_plane_reference_name="test5", endpoint="metrics", exported_namespace="org-multi-project", infrastructure_reference_kind="OpenStackCluster", infrastructure_reference_name="test5", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 1
    ``` 
  - `capi_clusters_status_conditions`
    e.g.:
    ```
    capi_clusters_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring", type="ControlPlaneInitialized"} | 1
    capi_clusters_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring", type="ControlPlaneReady"} | 1
    capi_clusters_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring", type="InfrastructureReady"} | 1
    capi_clusters_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring", type="Ready"} | 1
    capi_clusters_status_conditions{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring", type="ControlPlaneInitialized"} | 1
    capi_clusters_status_conditions{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring", type="ControlPlaneReady"} | 0
    capi_clusters_status_conditions{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring", type="InfrastructureReady"} | 1
    capi_clusters_status_conditions{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring", type="Ready"} | 0
    ```
  - `capi_clusters_status_phase`
    e.g.:
    ```
    capi_clusters_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", phase="Deleting", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", phase="Failed", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", phase="Pending", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", phase="Provisioned", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 1
    capi_clusters_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", phase="Provisioning", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", phase="Unknown", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", phase="Deleting", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", phase="Failed", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", phase="Pending", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", phase="Provisioned", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 1
    capi_clusters_status_phase{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", phase="Provisioning", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    capi_clusters_status_phase{cluster="test5", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-multi-project", instance="10.0.3.88:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", phase="Unknown", pod="cluster-api-monitoring-7b66457476-8zp8f", service="cluster-api-monitoring"} | 0
    ```




<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
