### PR TITLE
Cluster api machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `capi_openstackmachine_volume_disk_size`
   - `capi_openstackmachine_status_instance_state`
   - `capi_openstackmachine_status_failure`
+- initial support for Cluster API machines
+  - `capi_machine_info`
+  - `capi_machine_status_conditions`
+  - `capi_machine_status_phase`
 - initialize the "empty" app with serviceaccount only
 
 [Unreleased]: https://github.com/giantswarm/{APP-NAME}/tree/main

--- a/helm/cluster-api-monitoring/configuration/capi_machine.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_machine.yaml
@@ -1,0 +1,51 @@
+labelsFromPath:
+  name: [metadata, name]
+  cluster: [spec, clusterName]
+  namespace: [metadata, namespace]
+metrics:
+  - name: info
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          version: [spec, version]
+          failure_domain: [spec, failureDomain]
+          provider_id: [spec, providerID]
+  - name: status_nodeinfo
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          kernel_version: [status, nodeInfo, kernelVersion]
+          container_runtime_version: [status, nodeInfo, containerRuntimeVersion]
+          os_image: [status, nodeInfo, osImage]
+          kubelet_version: [status, nodeInfo, kubeletVersion]
+          kube_proxy_version: [status, nodeInfo, kubeProxyVersion]
+  - name: status_phase
+    each:
+      type: StateSet
+      stateSet:
+        path:
+          - status
+          - phase
+        list:
+          - Pending
+          - Provisioning
+          - Provisioned
+          - Deleting
+          - Failed
+          - Unknown
+          - Running
+        labelName: phase
+  - name: status_conditions
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - status
+        labelFromKey: reason
+        labelsFromPath:
+          type: [type]

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -64,3 +64,8 @@ monitoredResources:
       kind: OpenStackMachine
       version: v1alpha5
       plural: openstackmachines
+    machine:
+      group: cluster.x-k8s.io
+      kind: Machine
+      version: v1beta1
+      plural: machines


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR is based on #3 and add support for Cluster API machine monitoring

- add Cluster API machine metrics
 - `capi_machines_info`
    e.g.:
    ```
    capi_machines_info{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", failure_domain="gb-lon-2", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", provider_id="openstack:///513703e6-13d5-493a-8084-0ba2da306904", service="cluster-api-monitoring", version="v1.24.0"} | 1
   ```
 - `capi_machines_status_nodeinfo`
    e.g.:
    ```
    capi_machines_status_nodeinfo{cluster="galaxy", container="cluster-api-monitoring", container_runtime_version="containerd://1.5.7", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", kernel_version="5.4.0-109-generic", kube_proxy_version="v1.24.0", kubelet_version="v1.24.0", name="galaxy-72jq5", namespace="giantswarm", os_image="Ubuntu 20.04.4 LTS", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring"} | 1
   ```
  - `capi_machines_status_phase`
     e.g.:
     ```
    capi_machines_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", phase="Deleting", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring"} | 0
    capi_machines_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", phase="Failed", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring"} | 0
    capi_machines_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", phase="Pending", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring"} | 0
    capi_machines_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", phase="Provisioned", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring"} | 0
    capi_machines_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", phase="Provisioning", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring"} | 0
    capi_machines_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", phase="Running", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring"} | 1
    capi_machines_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", phase="Unknown", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring"} | 0
     ```
 - `capi_machines_status_conditions`
   e.g.:
   ```
       capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="APIServerPodHealthy"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="BootstrapReady"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="ControllerManagerPodHealthy"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="EtcdMemberHealthy"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="EtcdPodHealthy"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="HealthCheckSucceeded"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="InfrastructureReady"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="NodeHealthy"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="Ready"} | 1
    capi_machines_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.99:8080", job="cluster-api-monitoring", name="galaxy-72jq5", namespace="giantswarm", pod="cluster-api-monitoring-5f45dc4bdd-nthkr", service="cluster-api-monitoring", type="SchedulerPodHealthy"} | 1
    ```
 

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
