### PR TITLE
Capi openstack support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `capi_machinedeployment_status_available_replicas`
   - `capi_machinedeployment_status_unavailable_replicas`
   - `capi_machinedeployment_status_phase`
+- initial support for Cluster API openstack
+  - `capi_openstackcluster_info`
+  - `capi_openstackcluster_status_failure`
+  - `capi_openstackcluster_status_loadbalancer`
+  - `capi_openstackcluster_status_bastion`
+  - `capi_openstackmachine_info`
+  - `capi_openstackmachine_volume_disk_size`
+  - `capi_openstackmachine_status_instance_state`
+  - `capi_openstackmachine_status_failure`
 - initialize the "empty" app with serviceaccount only
 
 [Unreleased]: https://github.com/giantswarm/{APP-NAME}/tree/main

--- a/helm/cluster-api-monitoring/configuration/capi_openstackcluster.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_openstackcluster.yaml
@@ -1,0 +1,33 @@
+labelsFromPath:
+  name: [metadata, name]
+  namespace: [metadata, namespace]
+  cluster: [metadata, name]
+metrics:
+  - name: info
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          external_network: [spec, externalNetworkId]
+          control_plane_endpoint_ip: [spec, controlPlaneEndpoint, host]
+          control_plane_endpoint_port: [spec, controlPlaneEndpoint, port]
+  - name: status_failure
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          reason: [status, failureReason]
+  - name: status_loadbalancer
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          ip: [status, network, apiServerLoadBalancer, ip]
+          id: [status, network, apiServerLoadBalancer, id]
+  - name: status_bastion
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          ip: [status, bastion, floatingIP]
+          id: [status, bastion, id]

--- a/helm/cluster-api-monitoring/configuration/capi_openstackmachine.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_openstackmachine.yaml
@@ -1,0 +1,47 @@
+labelsFromPath:
+  name: [metadata, name]
+  namespace: [metadata, namespace]
+  cluster: [metadata, labels, cluster.x-k8s.io/cluster-name]
+metrics:
+  - name: info
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          machine_reference: [metadata, ownerReferences, "[kind=Machine]", name]
+          machine_set_reference:
+            [metadata, ownerReferences, "[kind=MachineSet]", name]
+          kubeadm_controlplane_reference:
+            [metadata, ownerReferences, "[kind=KubeadmControlPlane]", name]
+          image: [spec, image]
+          flavor: [spec, flavor]
+          instance_id: [spec, instanceID]
+  - name: volume_disk_size
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - spec
+          - rootVolume
+          - diskSize
+  - name: status_instance_state
+    each:
+      type: StateSet
+      stateSet:
+        path:
+          - status
+          - instanceState
+        list:
+          - BUILDING
+          - ACTIVE
+          - ERROR
+          - STOPPED
+          - SHUTOFF
+          - DELETED
+        labelName: state
+  - name: status_failure
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          reason: [status, failureReason]

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -54,3 +54,13 @@ monitoredResources:
       kind: MachineDeployment
       version: v1beta1
       plural: machinedeployments
+    openstackcluster:
+      group: infrastructure.cluster.x-k8s.io
+      kind: OpenStackCluster
+      version: v1alpha5
+      plural: openstackclusters
+    openstackmachine:
+      group: infrastructure.cluster.x-k8s.io
+      kind: OpenStackMachine
+      version: v1alpha5
+      plural: openstackmachines


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR is based on #3 and add support for Cluster API Openstack metrics

- `capi_openstackclusters_info`
  e.g.:
  ```
  capi_openstackclusters_info{cluster="<nil>", container="cluster-api-monitoring", control_plane_endpoint_ip="216.119.153.216", control_plane_endpoint_port="6443", endpoint="metrics", exported_namespace="org-multi-project", external_network="cdbcb519-1f91-43fb-b0a9-312f0abf8f12", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="test5", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring"} | 1
  ```
- `capi_openstackclusters_status_failure` (see the `reason` label --> `<nil>` if everything is fine)
  e.g.:
  ```
  capi_openstackclusters_status_failure{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", reason="<nil>", service="cluster-api-monitoring"} | 1
  ```
- `capi_openstackclusters_status_loadbalancer`
  e.g.:
  ```
  capi_openstackclusters_status_loadbalancer{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", id="e7cf6212-9fa0-49bf-884f-22f739e06ca7", instance="10.0.3.246:8080", ip="216.119.153.219", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring"} | 1  
  ```
- `capi_openstackclusters_status_bastion`
  e.g.:
  ```
  capi_openstackclusters_status_bastion{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", id="15bd1937-5a95-4a92-95ac-5970041a7903", instance="10.0.3.246:8080", ip="216.119.153.48", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring"} | 1
  ```
- `capi_openstackmachines_info`
  e.g.:
  ```
  capi_openstackmachines_info{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", flavor="n1.medium", image="<nil>", instance="10.0.3.246:8080", instance_id="25316d57-d70d-470c-a8ff-d43b272730e6", job="cluster-api-monitoring", kubeadm_controlplane_reference="<nil>", machine_reference="galaxy-galaxy-lon-2-7db9b8cddb-4gmnn", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring"} | 1
  ```
- `capi_openstackmachines_volume_disk_size`
  e.g.:
  ```
  capi_openstackmachines_volume_disk_size{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring"} | 50
  ```
- `capi_openstackmachines_status_instance_state`
  e.g.:
  ```
  capi_openstackmachines_status_instance_state{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring", state="ACTIVE"} | 1
  capi_openstackmachines_status_instance_state{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring", state="BUILDING"} | 0
  capi_openstackmachines_status_instance_state{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring", state="DELETED"} | 0
  capi_openstackmachines_status_instance_state{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring", state="ERROR"} | 0
  capi_openstackmachines_status_instance_state{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring", state="SHUTOFF"} | 0
  capi_openstackmachines_status_instance_state{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", service="cluster-api-monitoring", state="STOPPED"} | 0
  ```
- `capi_openstackmachines_status_failure`  (see the `reason` label --> `<nil>` if everything is fine)
  e.g.:
  ```
  capi_openstackmachines_status_failure{cluster="<nil>", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.3.246:8080", job="cluster-api-monitoring", name="galaxy-galaxy-7833d431-pslwk", namespace="giantswarm", pod="cluster-api-monitoring-66bcb6d9f5-s8zrp", reason="<nil>", service="cluster-api-monitoring"} | 1
  ```

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
