### PR TITLE
add support for CAPI machinedeployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `capi_machinehealthcheck_status_current_healthy`
   - `capi_machinehealthcheck_status_expected_machines`
   - `capi_machinehealthcheck_status_remediations_allowed`
+- initial support for Cluster API machinedeployments
+  - `capi_machinedeployment_info`
+  - `capi_machinedeployment_status_conditions`
+  - `capi_machinedeployment_spec_replicas`
+  - `capi_machinedeployment_status_replicas`
+  - `capi_machinedeployment_status_ready_replicas`
+  - `capi_machinedeployment_status_available_replicas`
+  - `capi_machinedeployment_status_unavailable_replicas`
+  - `capi_machinedeployment_status_phase`
 - initialize the "empty" app with serviceaccount only
 
 [Unreleased]: https://github.com/giantswarm/{APP-NAME}/tree/main

--- a/helm/cluster-api-monitoring/configuration/capi_machinedeployment.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_machinedeployment.yaml
@@ -1,0 +1,81 @@
+labelsFromPath:
+  version: [spec, template, spec, version]
+  name: [metadata, name]
+  namespace: [metadata, namespace]
+  cluster: [spec, template, spec, clusterName]
+metrics:
+  - name: status_conditions
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - status
+        labelFromKey: reason
+        labelsFromPath:
+          type: [type]
+  - name: spec_replicas
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - spec
+          - replicas
+  - name: status_replicas
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - replicas
+  - name: status_ready_replicas
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - readyReplicas
+  - name: status_available_replicas
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - availableReplicas
+  - name: status_unavailable_replicas
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - unavailableReplicas
+  - name: info
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          infrastructure_reference_name:
+            [spec, template, spec, infrastructureRef, name]
+          infrastructure_reference_type:
+            [spec, template, spec, infrastructureRef, kind]
+          bootstrap_configuration_reference_name:
+            [spec, template, spec, bootstrap, configRef, name]
+          bootstrap_configuration_reference_type:
+            [spec, template, spec, bootstrap, configRef, type]
+          failure_domain: [spec, template, spec, failureDomain]
+  - name: status_phase
+    each:
+      type: StateSet
+      stateSet:
+        path:
+          - status
+          - phase
+        list:
+          - Running
+          - ScalingUp
+          - ScalingDown
+          - Failed
+          - Unknown
+        labelName: phase

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -49,3 +49,8 @@ monitoredResources:
       kind: MachineHealthCheck
       version: v1beta1
       plural: machinehealthchecks
+    machinedeployment:
+      group: cluster.x-k8s.io
+      kind: MachineDeployment
+      version: v1beta1
+      plural: machinedeployments


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- `capi_machinedeployment_info`
  e.g.
  ```
  capi_machinedeployment_info{bootstrap_configuration_reference_name="galaxy-galaxy-lon-1", bootstrap_configuration_reference_type="<nil>", cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", failure_domain="gb-lon-1", infrastructure_reference_name="galaxy-galaxy-7833d431", infrastructure_reference_type="OpenStackMachineTemplate", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 1
   ```
- `capi_machinedeployment_status_conditions`
  e.g.
  ```
  capi_machinedeployment_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", type="Available", version="v1.24.0"} | 1
  capi_machinedeployment_status_conditions{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", type="Ready", version="v1.24.0"} | 1
   ```
- `capi_machinedeployment_spec_replicas`
  e.g.
  ```
  capi_machinedeployment_spec_replicas{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 1
  ```
- `capi_machinedeployment_status_replicas`
  e.g.
  ```
  capi_machinedeployment_status_replicas{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 1
  ```
- `capi_machinedeployment_status_ready_replicas`
  e.g.
  ```
  capi_machinedeployment_status_ready_replicas{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 1
  ```
- `capi_machinedeployment_status_available_replicas`
  e.g.
  ```
  capi_machinedeployment_status_available_replicas{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 1
  ```
- `capi_machinedeployment_status_unavailable_replicas`
  e.g.
  ```
  capi_machinedeployment_status_unavailable_replicas{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 1
  ```
- `capi_machinedeployment_status_phase`
  e.g.
  ```
  capi_machinedeployment_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", phase="Failed", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 0
  capi_machinedeployment_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", phase="Running", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 1
  capi_machinedeployment_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", phase="ScalingDown", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 0
  capi_machinedeployment_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", phase="ScalingUp", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 0
  capi_machinedeployment_status_phase{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.80:8080", job="cluster-api-monitoring", name="galaxy-galaxy-lon-1", namespace="giantswarm", phase="Unknown", pod="cluster-api-monitoring-649546f448-pr7mb", service="cluster-api-monitoring", version="v1.24.0"} | 0
  ```

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
