### PR TITLE
add support for CAPI machinehealthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Add
 
-- initial support for cluster CR monitoring
+- initial support for Cluster API machinehealthcheck
+  - `capi_machinehealthcheck_status_current_healthy`
+  - `capi_machinehealthcheck_status_expected_machines`
+  - `capi_machinehealthcheck_status_remediations_allowed`
 - initialize the "empty" app with serviceaccount only
 
 [Unreleased]: https://github.com/giantswarm/{APP-NAME}/tree/main

--- a/helm/cluster-api-monitoring/configuration/capi_machinehealthcheck.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_machinehealthcheck.yaml
@@ -1,0 +1,26 @@
+labelsFromPath:
+  name: [metadata, name]
+  namespace: [metadata, namespace]
+  cluster: [spec, clusterName]
+metrics:
+  - name: status_current_healthy
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - currentHealthy
+  - name: status_expected_machines
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - expectedMachines
+  - name: status_remediations_allowed
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - remediationsAllowed

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -43,3 +43,9 @@ monitoredResources:
   #     kind: Foo                      # kind is the kind of the CR
   #     version: v1alpha1              # version is the version of the CR
   #     plural: foos                   # plural has to be the lower case plural string of kind - required for ClusterRole templating and must be done as KSM register resources as plural (doesn't matter if core Kubernetes or CRs)
+  capi:
+    machinehealthcheck:
+      group: cluster.x-k8s.io
+      kind: MachineHealthCheck
+      version: v1beta1
+      plural: machinehealthchecks


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR add support for capi machinehealthchecks

- `capi_machinehealthcheck_status_current_healthy`
   e.g.
   ```
   capi_machinehealthcheck_status_current_healthy{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.55:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-f76bc67b5-svz77", service="cluster-api-monitoring"} | 6
   ```
- `capi_machinehealthcheck_status_expected_machines`
   e.g.
   ```
   capi_machinehealthcheck_status_expected_machines{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.55:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-f76bc67b5-svz77", service="cluster-api-monitoring"} | 6
   ```
- `capi_machinehealthcheck_status_remediations_allowed`
   e.g.
   ```
   capi_machinehealthcheck_status_remediations_allowed{cluster="galaxy", container="cluster-api-monitoring", endpoint="metrics", exported_namespace="org-giantswarm", instance="10.0.2.55:8080", job="cluster-api-monitoring", name="galaxy", namespace="giantswarm", pod="cluster-api-monitoring-f76bc67b5-svz77", service="cluster-api-monitoring"} | 2
   ```
<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] metric name change doesn't affect existing alerts
