### PR TITLE
add upstream CAPI metrics configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Change
 
+
+- `cluster_name` label from `capi_cluster` metrics got removed as the value is a duplicate of the `name` label
+- Align all `capi` metrics with upstream
+  - `capi_machinedeployment_status_unavailable_replicas` changed to `capi_machinedeployment_status_replicas_unavailable`
+  - `*_status_conditions` changed to `*_status_condition` (plural to singular)
 - Moved from `ServiceMonitor` to `PodMonitor` as there the service itself isn't used
 - Remove `plural` from configuration as not needed anymore for `kube-state-metrics` to run
 - Update to `kube-state-metrics` version `v2.7.0`

--- a/helm/cluster-api-monitoring/configuration/capi_cluster.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_cluster.yaml
@@ -1,43 +1,75 @@
 labelsFromPath:
-  name: [metadata, name]
-  cluster_name: [metadata, name]
-  namespace: [metadata, namespace]
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
 metrics:
-  - name: status_conditions
-    help: The current status conditions of a cluster.
+  - name: status_condition
+    help: The condition of a cluster.
     each:
-      type: StateSet
       stateSet:
-        path:
-          - status
-          - conditions
+        labelName: status
+        labelsFromPath:
+          type:
+            - type
         list:
           - "True"
           - "False"
-          - "Unknown"
-        valueFrom:
-          - status
-        labelName: status
-        labelsFromPath:
-          type: [type]
-  - name: info
-    each:
-      type: Info
-      info:
-        labelsFromPath:
-          control_plane_endpoint_host: [spec, controlPlaneEndpoint, host]
-          control_plane_endpoint_port: [spec, controlPlaneEndpoint, port]
-          control_plane_reference_kind: [spec, controlPlaneRef, kind]
-          control_plane_reference_name: [spec, controlPlaneRef, name]
-          infrastructure_reference_kind: [spec, infrastructureRef, kind]
-          infrastructure_reference_name: [spec, infrastructureRef, name]
-  - name: status_phase
-    each:
-      type: StateSet
-      stateSet:
+          - Unknown
         path:
           - status
-          - phase
+          - conditions
+        valueFrom:
+          - status
+      type: StateSet
+  - name: info
+    help: Information about a cluster.
+    each:
+      info:
+        labelsFromPath:
+          topology_version:
+            - spec
+            - topology
+            - version
+          topology_class:
+            - spec
+            - topology
+            - class
+          control_plane_endpoint_host:
+            - spec
+            - controlPlaneEndpoint
+            - host
+          control_plane_endpoint_port:
+            - spec
+            - controlPlaneEndpoint
+            - port
+          control_plane_reference_kind:
+            - spec
+            - controlPlaneRef
+            - kind
+          control_plane_reference_name:
+            - spec
+            - controlPlaneRef
+            - name
+          infrastructure_reference_kind:
+            - spec
+            - infrastructureRef
+            - kind
+          infrastructure_reference_name:
+            - spec
+            - infrastructureRef
+            - name
+      type: Info
+  - name: status_phase
+    help: The clusters current phase.
+    each:
+      stateSet:
+        labelName: phase
         list:
           - Pending
           - Provisioning
@@ -45,20 +77,35 @@ metrics:
           - Deleting
           - Failed
           - Unknown
-        labelName: phase
+        path:
+          - status
+          - phase
+      type: StateSet
   - name: created
     help: Unix creation timestamp.
     each:
-      type: Gauge
       gauge:
         path:
           - metadata
           - creationTimestamp
-  - name: spec_paused
-    each:
       type: Gauge
+  - name: spec_paused
+    help: Whether the cluster is paused and any of its resources will not be processed by the controllers.
+    each:
       gauge:
         nilIsZero: true
         path:
           - spec
           - paused
+      type: Gauge
+  - name: annotation_paused
+    help: Whether the cluster is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_kubeadmcontrolplane.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_kubeadmcontrolplane.yaml
@@ -1,18 +1,30 @@
 labelsFromPath:
-  name: [metadata, name]
-  namespace: [metadata, namespace]
-  uid: [metadata, uid]
-  cluster_name: [metadata, ownerReferences, "[kind=Cluster]", name]
+  cluster_name:
+    - metadata
+    - ownerReferences
+    - "[kind=Cluster]"
+    - name
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
 metrics:
-  - each:
+  - name: created
+    help: Unix creation timestamp.
+    each:
       gauge:
         path:
           - metadata
           - creationTimestamp
       type: Gauge
-    name: created
-    help: Unix creation timestamp.
-  - each:
+  - name: status_condition
+    help: The condition of a kubeadmcontrolplane.
+    each:
       stateSet:
         labelName: status
         labelsFromPath:
@@ -28,48 +40,53 @@ metrics:
         valueFrom:
           - status
       type: StateSet
-    name: status_conditions
-    help: The current status conditions of a kubeadmcontrolplane.
-  - each:
+  - name: status_replicas
+    help: The number of replicas per kubeadmcontrolplane.
+    each:
       gauge:
         path:
           - status
           - replicas
         nilIsZero: true
       type: Gauge
-    name: status_replicas
-  - each:
+  - name: status_replicas_ready
+    help: The number of ready replicas per kubeadmcontrolplane.
+    each:
       gauge:
         path:
           - status
           - readyReplicas
         nilIsZero: true
       type: Gauge
-    name: status_replicas_ready
-  - each:
+  - name: status_replicas_unavailable
+    help: The number of unavailable replicas per kubeadmcontrolplane.
+    each:
       gauge:
         path:
           - status
           - unavailableReplicas
         nilIsZero: true
       type: Gauge
-    name: status_replicas_unavailable
-  - each:
+  - name: status_replicas_updated
+    help: The number of updated replicas per kubeadmcontrolplane.
+    each:
       gauge:
         path:
           - status
           - updatedReplicas
         nilIsZero: true
       type: Gauge
-    name: status_replicas_updated
-  - each:
+  - name: spec_replicas
+    help: The number of desired machines for a kubeadmcontrolplane.
+    each:
       gauge:
         path:
           - spec
           - replicas
       type: Gauge
-    name: spec_replicas
-  - each:
+  - name: spec_strategy_rollingupdate_max_surge
+    help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a kubeadmcontrolplane.
+    each:
       gauge:
         path:
           - spec
@@ -77,8 +94,9 @@ metrics:
           - rollingUpdate
           - maxSurge
       type: Gauge
-    name: spec_strategy_rollingupdate_max_surge
-  - each:
+  - name: owner
+    help: Owner references.
+    each:
       info:
         labelsFromPath:
           owner_is_controller:
@@ -93,12 +111,23 @@ metrics:
           - metadata
           - ownerReferences
       type: Info
-    name: owner
-  - each:
+  - name: info
+    help: Information about a kubeadmcontrolplane.
+    each:
       info:
         labelsFromPath:
           version:
             - spec
             - version
       type: Info
-    name: info
+  - name: annotation_paused
+    help: Whether the kubeadmcontrolplane is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_machine.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_machine.yaml
@@ -1,44 +1,100 @@
 labelsFromPath:
-  name: [metadata, name]
-  cluster_name: [spec, clusterName]
-  namespace: [metadata, namespace]
+  cluster_name:
+    - spec
+    - clusterName
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
 metrics:
   - name: info
+    help: Information about a machine.
     each:
-      type: Info
       info:
         labelsFromPath:
-          version: [spec, version]
-          failure_domain: [spec, failureDomain]
-          provider_id: [spec, providerID]
-  - name: status_nodeinfo
-    each:
-      type: Info
-      info:
-        labelsFromPath:
-          kernel_version: [status, nodeInfo, kernelVersion]
-          container_runtime_version: [status, nodeInfo, containerRuntimeVersion]
-          os_image: [status, nodeInfo, osImage]
-          kubelet_version: [status, nodeInfo, kubeletVersion]
-          kube_proxy_version: [status, nodeInfo, kubeProxyVersion]
-  - name: status_phase
-    each:
-      type: StateSet
-      stateSet:
-        path:
+          container_runtime_version:
           - status
-          - phase
+          - nodeInfo
+          - containerRuntimeVersion
+          failure_domain:
+          - spec
+          - failureDomain
+          kernel_version:
+          - status
+          - nodeInfo
+          - kernelVersion
+          kubelet_version:
+          - status
+          - nodeInfo
+          - kubeletVersion
+          kube_proxy_version:
+          - status
+          - nodeInfo
+          - kubeProxyVersion
+          os_image:
+          - status
+          - nodeInfo
+          - osImage
+          provider_id:
+          - spec
+          - providerID
+          version:
+          - spec
+          - version
+      type: Info
+  - name: addresses
+    help: Address information about a machine.
+    each:
+      info:
+        path:
+        - status
+        - addresses
+        labelsFromPath:
+          type:
+          - type
+          address:
+          - address
+      type: Info
+  - name: status_noderef
+    help: Information about the node reference of a machine.
+    each:
+      info:
+        labelsFromPath:
+          node_name:
+            - status
+            - nodeRef
+            - name
+          node_uid:
+            - status
+            - nodeRef
+            - uid
+      type: Info
+  - name: status_phase
+    help: The machines current phase.
+    each:
+      stateSet:
+        labelName: phase
         list:
           - Pending
           - Provisioning
           - Provisioned
+          - Running
           - Deleting
           - Deleted
           - Failed
           - Unknown
-          - Running
-        labelName: phase
-  - each:
+        path:
+          - status
+          - phase
+      type: StateSet
+  - name: status_condition
+    help: The condition of a machine.
+    each:
       stateSet:
         labelName: status
         labelsFromPath:
@@ -54,13 +110,39 @@ metrics:
         valueFrom:
           - status
       type: StateSet
-    name: status_conditions
-    help: The current status conditions of a machine.
-  - each:
+  - name: created
+    help: Unix creation timestamp.
+    each:
       gauge:
         path:
           - metadata
           - creationTimestamp
       type: Gauge
-    name: created
-    help: Unix creation timestamp.
+  - name: annotation_paused
+    help: Whether the machine is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_machinedeployment.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_machinedeployment.yaml
@@ -1,11 +1,19 @@
 labelsFromPath:
-  version: [spec, template, spec, version]
-  name: [metadata, name]
-  namespace: [metadata, namespace]
-  cluster_name: [spec, clusterName]
+  cluster_name:
+    - spec
+    - clusterName
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
 metrics:
-  - name: status_conditions
-    help: The current status conditions of a machinedeployment.
+  - name: status_condition
+    help: The condition of a machinedeployment.
     each:
       stateSet:
         labelName: status
@@ -23,85 +31,176 @@ metrics:
           - status
       type: StateSet
   - name: spec_replicas
+    help: The number of desired machines for a machinedeployment.
     each:
-      type: Gauge
       gauge:
         path:
           - spec
           - replicas
-  - name: status_replicas
-    each:
       type: Gauge
+  - name: spec_strategy_rollingupdate_max_surge
+    help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a machinedeployment.
+    each:
+      gauge:
+        path:
+          - spec
+          - strategy
+          - rollingUpdate
+          - maxSurge
+      type: Gauge
+  - name: spec_strategy_rollingupdate_max_unavailable
+    help: Maximum number of unavailable replicas during a rolling update of a machinedeployment.
+    each:
+      gauge:
+        path:
+          - spec
+          - strategy
+          - rollingUpdate
+          - maxUnavailable
+      type: Gauge
+  - name: status_replicas
+    help: The number of replicas per machinedeployment.
+    each:
       gauge:
         path:
           - status
           - replicas
         nilIsZero: true
-  - name: status_replicas_ready
-    each:
       type: Gauge
+  - name: status_replicas_ready
+    help: The number of ready replicas per machinedeployment.
+    each:
       gauge:
         path:
           - status
           - readyReplicas
         nilIsZero: true
-  - name: status_replicas_available
-    each:
       type: Gauge
+  - name: status_replicas_available
+    help: The number of available replicas per machinedeployment.
+    each:
       gauge:
         path:
           - status
           - availableReplicas
         nilIsZero: true
-  - name: status_unavailable_replicas
-    each:
       type: Gauge
+  - name: status_replicas_unavailable
+    help: The number of unavailable replicas per machinedeployment.
+    each:
       gauge:
         path:
           - status
           - unavailableReplicas
         nilIsZero: true
+      type: Gauge
+  - name: status_replicas_updated
+    help: The number of updated replicas per machinedeployment.
+    each:
+      gauge:
+        path:
+          - status
+          - updatedReplicas
+        nilIsZero: true
+      type: Gauge
   - name: info
     each:
       type: Info
       info:
         labelsFromPath:
           infrastructure_reference_name:
-            [spec, template, spec, infrastructureRef, name]
-          infrastructure_reference_type:
-            [spec, template, spec, infrastructureRef, kind]
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - name
+          infrastructure_reference_kind:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - kind
           bootstrap_configuration_reference_name:
-            [spec, template, spec, bootstrap, configRef, name]
-          bootstrap_configuration_reference_type:
-            [spec, template, spec, bootstrap, configRef, type]
-          failure_domain: [spec, template, spec, failureDomain]
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - name
+          bootstrap_configuration_reference_kind:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - kind
+          failure_domain:
+            - spec
+            - template
+            - spec
+            - failureDomain
+          version:
+            - spec
+            - template
+            - spec
+            - version
   - name: status_phase
+    help: The machinedeployments current phase.
     each:
-      type: StateSet
       stateSet:
+        labelName: phase
+        list:
+          - ScalingUp
+          - ScalingDown
+          - Running
+          - Failed
+          - Unknown
         path:
           - status
           - phase
-        list:
-          - Running
-          - ScalingUp
-          - ScalingDown
-          - Failed
-          - Unknown
-        labelName: phase
-  - each:
+      type: StateSet
+  - name: created
+    help: Unix creation timestamp.
+    each:
       gauge:
         path:
           - metadata
           - creationTimestamp
       type: Gauge
-    name: created
-    help: Unix creation timestamp.
-  - each:
+  - name: annotation_paused
+    help: Whether the machinedeployment is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: spec_paused
+    help: Whether the machinedeployment is paused and any of its resources will not be processed by the controllers.
+    each:
       gauge:
         nilIsZero: true
         path:
           - spec
           - paused
       type: Gauge
-    name: spec_paused
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_machinehealthcheck.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_machinehealthcheck.yaml
@@ -1,34 +1,92 @@
 labelsFromPath:
-  name: [metadata, name]
-  namespace: [metadata, namespace]
-  cluster_name: [spec, clusterName]
+  cluster_name:
+    - spec
+    - clusterName
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
 metrics:
   - name: status_current_healthy
+    help: Current number of healthy machines.
     each:
-      type: Gauge
       gauge:
         path:
           - status
           - currentHealthy
-  - name: status_expected_machines
-    each:
       type: Gauge
+  - name: status_expected_machines
+    help: Total number of pods counted by this machinehealthcheck.
+    each:
       gauge:
         path:
           - status
           - expectedMachines
-  - name: status_remediations_allowed
-    each:
       type: Gauge
+  - name: status_remediations_allowed
+    help: Number of machine remediations that are currently allowed.
+    each:
       gauge:
         path:
           - status
           - remediationsAllowed
-  - each:
+      type: Gauge
+  - name: created
+    help: Unix creation timestamp.
+    each:
       gauge:
         path:
           - metadata
           - creationTimestamp
       type: Gauge
-    name: created
-    help: Unix creation timestamp.
+  - name: annotation_paused
+    help: Whether the machinehealthcheck is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: status_condition
+    help: The condition of a machinehealthcheck.
+    each:
+      stateSet:
+        labelName: status
+        labelsFromPath:
+          type:
+            - type
+        list:
+          - "True"
+          - "False"
+          - Unknown
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - status
+      type: StateSet
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_machineset.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_machineset.yaml
@@ -1,26 +1,37 @@
 labelsFromPath:
-  name: [metadata, name]
-  namespace: [metadata, namespace]
-  uid: [metadata, uid]
-  cluster_name: [spec, clusterName]
+  cluster_name:
+    - spec
+    - clusterName
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
 metrics:
-  - each:
+  - name: created
+    help: Unix creation timestamp.
+    each:
       gauge:
         path:
           - metadata
           - creationTimestamp
       type: Gauge
-    name: created
-    help: Unix creation timestamp.
-  - each:
+  - name: status_available_replicas
+    help: The number of available replicas per machineset.
+    each:
       gauge:
         path:
           - status
           - availableReplicas
         nilIsZero: true
       type: Gauge
-    name: status_available_replicas
-  - each:
+  - name: status_condition
+    help: The condition of a machineset.
+    each:
       stateSet:
         labelName: status
         labelsFromPath:
@@ -36,8 +47,6 @@ metrics:
         valueFrom:
           - status
       type: StateSet
-    name: status_conditions
-    help: The current status conditions of a machineset.
   - each:
       gauge:
         path:
@@ -46,30 +55,55 @@ metrics:
         nilIsZero: true
       type: Gauge
     name: status_replicas
-  - each:
+  - name: status_fully_labeled_replicas
+    help: The number of fully labeled replicas per machineset.
+    each:
       gauge:
         path:
           - status
           - fullyLabeledReplicas
       type: Gauge
-    name: status_fully_labeled_replicas
-  - each:
+  - name: status_replicas
+    help: The number of replicas per machineset.
+    each:
+      gauge:
+        path:
+          - status
+          - replicas
+        nilIsZero: true
+      type: Gauge
+  - name: status_ready_replicas
+    help: The number of ready replicas per machineset.
+    each:
       gauge:
         path:
           - status
           - readyReplicas
         nilIsZero: true
       type: Gauge
-    name: status_ready_replicas
-  - each:
+  - name: spec_replicas
+    help: The number of desired machines for a machineset.
+    each:
       gauge:
         path:
           - spec
           - replicas
         nilIsZero: true
       type: Gauge
-    name: spec_replicas
-  - each:
+  - name: annotation_paused
+    help: Whether the machineset is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: owner
+    help: Owner references.
+    each:
       info:
         labelsFromPath:
           owner_is_controller:
@@ -84,4 +118,14 @@ metrics:
           - metadata
           - ownerReferences
       type: Info
-    name: owner
+  - name: info
+    help: Information about a machineset.
+    each:
+      info:
+        labelsFromPath:
+          version:
+            - spec
+            - template
+            - spec
+            - version
+      type: Info

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -6,9 +6,9 @@ project:
   commit: "[[ .SHA ]]"
 
 image:
-  registry: docker.io
+  registry: quay.io
   name: giantswarm/kube-state-metrics
-  tag: v2.7.0
+  tag: v2.7.0-b7a7070
   pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:
* align the CAPI related metrics with upstream from https://github.com/kubernetes-sigs/cluster-api/pull/7886
* bind `KSM` to a custom build from latest `main` (xref: https://github.com/kubernetes/kube-state-metrics/commit/b7a7070e87ba4299a90587c8c2d5c7647db1ba42)

With the merge of the `KSM` behavior has changed a bit and instead of the autogenarted `group`, `version`, `kind` labels, the new autogenerated labels are `customresource_group`, `customresource_version` and `customresource_kind`.

e.g:
```
capi_machine_info{cluster_name="glippy",container_runtime_version="containerd://1.6.0",customresource_group="cluster.x-k8s.io",customresource_kind="Machine",customresource_version="v1beta1",failure_domain="3",kernel_version="5.11.0-1028-azure",kube_proxy_version="v1.22.7",kubelet_version="v1.22.7",name="glippy-dnxdb",namespace="org-giantswarm",os_image="Ubuntu 20.04.3 LTS",provider_id="azure:///subscriptions/<random-subscription-id>/resourceGroups/glippy/providers/Microsoft.Compute/virtualMachines/glippy-control-plane-4fg59",uid="998fe651-704e-4d72-b447-291cc8778544",version="v1.22.7"} 1
```

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] metric name change doesn't affect existing alerts
