### PR TITLE
machinepool capi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Add
+
+- initial support for Cluster API `MachinePools` add the following metrics:
+  - `capi_machinepool_annotation_paused`
+  - `capi_machinepool_created`
+  - `capi_machinepool_info`
+  - `capi_machinepool_owner`
+  - `capi_machinepool_spec_replicas`
+  - `capi_machinepool_status_condition`
+  - `capi_machinepool_status_phase`
+  - `capi_machinepool_status_replicas`
+  - `capi_machinepool_status_replicas_available`
+  - `capi_machinepool_status_replicas_ready`
+  - `capi_machinepool_status_replicas_unavailable`
+
+### Change
 
 - Moved from `ServiceMonitor` to `PodMonitor` as there the service itself isn't used
 - Remove `plural` from configuration as not needed anymore for `kube-state-metrics` to run

--- a/helm/cluster-api-monitoring/configuration/capi_machinepool.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_machinepool.yaml
@@ -1,0 +1,168 @@
+labelsFromPath:
+  cluster_name:
+    - spec
+    - clusterName
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
+metrics:
+  - name: status_condition
+    help: The condition of a machinepool.
+    each:
+      stateSet:
+        labelName: status
+        labelsFromPath:
+          type:
+            - type
+        list:
+          - "True"
+          - "False"
+          - Unknown
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - status
+      type: StateSet
+  - name: spec_replicas
+    help: The number of desired machines for a machinepool.
+    each:
+      gauge:
+        path:
+          - spec
+          - replicas
+      type: Gauge
+  - name: status_replicas
+    help: The number of replicas per machinepool.
+    each:
+      gauge:
+        path:
+          - status
+          - replicas
+        nilIsZero: true
+      type: Gauge
+  - name: status_replicas_ready
+    help: The number of ready replicas per machinepool.
+    each:
+      gauge:
+        path:
+          - status
+          - readyReplicas
+        nilIsZero: true
+      type: Gauge
+  - name: status_replicas_available
+    help: The number of available replicas per machinepool.
+    each:
+      gauge:
+        path:
+          - status
+          - availableReplicas
+        nilIsZero: true
+      type: Gauge
+  - name: status_replicas_unavailable
+    help: The number of unavailable replicas per machinepool.
+    each:
+      gauge:
+        path:
+          - status
+          - unavailableReplicas
+        nilIsZero: true
+      type: Gauge
+  - name: info
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          infrastructure_reference_name:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - name
+          infrastructure_reference_kind:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - kind
+          bootstrap_configuration_reference_name:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - name
+          bootstrap_configuration_reference_kind:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - kind
+          failure_domain:
+            - spec
+            - template
+            - spec
+            - failureDomain
+          version:
+            - spec
+            - template
+            - spec
+            - version
+  - name: status_phase
+    help: The machinepools current phase.
+    each:
+      stateSet:
+        labelName: phase
+        list:
+          - ScalingUp
+          - ScalingDown
+          - Running
+          - Failed
+          - Unknown
+        path:
+          - status
+          - phase
+      type: StateSet
+  - name: created
+    help: Unix creation timestamp.
+    each:
+      gauge:
+        path:
+          - metadata
+          - creationTimestamp
+      type: Gauge
+  - name: annotation_paused
+    help: Whether the machinepool is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

Towards https://github.com/giantswarm/giantswarm/issues/25185, this PR adds initial support for Cluster API `machinePools`.

> For now please ignore the `version` label when the value is `v1beta1`.
> The `KSM` implementation has changed and depending on the result of https://github.com/kubernetes/kube-state-metrics/pull/1942 and https://github.com/kubernetes/kube-state-metrics/issues/1943 i will change the label name to `kubernetes_version` (or whatever make sense after discussing this with CAPI upstream)

```
# HELP capi_machinepool_status_condition The condition of a machinepool.
# TYPE capi_machinepool_status_condition gauge
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="False",type="BootstrapReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="False",type="InfrastructureReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="False",type="Ready",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="False",type="ReplicasReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="True",type="BootstrapReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="True",type="InfrastructureReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="True",type="Ready",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="True",type="ReplicasReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="Unknown",type="BootstrapReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="Unknown",type="InfrastructureReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="Unknown",type="Ready",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_condition{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",status="Unknown",type="ReplicasReady",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
```

```
# HELP capi_machinepool_spec_replicas The number of desired machines for a machinepool.
# TYPE capi_machinepool_spec_replicas gauge
capi_machinepool_spec_replicas{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
```

```
# HELP capi_machinepool_status_replicas The number of replicas per machinepool.
# TYPE capi_machinepool_status_replicas gauge
capi_machinepool_status_replicas{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
```

```
# HELP capi_machinepool_status_replicas_ready The number of ready replicas per machinepool.
# TYPE capi_machinepool_status_replicas_ready gauge
capi_machinepool_status_replicas_ready{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
```

```
# HELP capi_machinepool_status_replicas_available The number of available replicas per machinepool.
# TYPE capi_machinepool_status_replicas_available gauge
capi_machinepool_status_replicas_available{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
```

```
# HELP capi_machinepool_status_replicas_unavailable The number of unavailable replicas per machinepool.
# TYPE capi_machinepool_status_replicas_unavailable gauge
capi_machinepool_status_replicas_unavailable{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
```

```
# HELP capi_machinepool_info 
# TYPE capi_machinepool_info gauge
capi_machinepool_info{bootstrap_configuration_reference_kind="KubeadmConfig",bootstrap_configuration_reference_name="marioc1-def00-b78dd5d7",cluster_name="marioc1",group="cluster.x-k8s.io",infrastructure_reference_kind="AzureMachinePool",infrastructure_reference_name="marioc1-def00-3830f64e",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1.24.8"} 1
```

```
# HELP capi_machinepool_status_phase The machinepools current phase.
# TYPE capi_machinepool_status_phase gauge
capi_machinepool_status_phase{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",phase="Failed",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_phase{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",phase="Running",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
capi_machinepool_status_phase{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",phase="ScalingDown",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_phase{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",phase="ScalingUp",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
capi_machinepool_status_phase{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",phase="Unknown",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 0
```

```
# HELP capi_machinepool_created Unix creation timestamp.
# TYPE capi_machinepool_created gauge
capi_machinepool_created{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1.672752467e+09
```

```
# HELP capi_machinepool_annotation_paused Whether the machinepool is paused and any of its resources will not be processed by the controllers.
# TYPE capi_machinepool_annotation_paused gauge
capi_machinepool_annotation_paused{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",paused_value="true",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
```

```
# HELP capi_machinepool_owner Owner references.
# TYPE capi_machinepool_owner gauge
capi_machinepool_owner{cluster_name="marioc1",group="cluster.x-k8s.io",kind="MachinePool",name="marioc1-def00",namespace="org-multi-project",owner_kind="Cluster",owner_name="marioc1",owner_uid="dd5ed135-1a9a-4687-97da-8133af09cf13",uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",version="v1beta1"} 1
```

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
