### PR TITLE
CAPZ support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Change
+
+- Drop `uid` label to reduce cardinality
+
+### Add
+
+- initial support for Cluster API Provider Azure CRs:
+  - `capi_azurecluster_annotation_paused`
+  - `capi_azurecluster_created`
+  - `capi_azurecluster_info`
+  - `capi_azurecluster_owner`
+  - `capi_azurecluster_status_conditions`
+  - `capi_azurecluster_status_ready`
+  - `capi_azuremachine_annotation_paused`
+  - `capi_azuremachine_created`
+  - `capi_azuremachine_info`
+  - `capi_azuremachine_owner`
+  - `capi_azuremachine_status_addresses`
+  - `capi_azuremachine_status_conditions`
+  - `capi_azuremachine_status_ready`
+  - `capi_azuremachinepool_annotation_paused`
+  - `capi_azuremachinepool_created`
+  - `capi_azuremachinepool_info`
+  - `capi_azuremachinepool_owner`
+  - `capi_azuremachinepool_status_addresses`
+  - `capi_azuremachinepool_status_conditions`
+  - `capi_azuremachinepool_status_image_info`
+  - `capi_azuremachinepool_status_ready`
+  - `capi_azuremachinepool_status_replicas`
+  - `capi_azuremachinepoolmachine_annotation_paused`
+  - `capi_azuremachinepoolmachine_created`
+  - `capi_azuremachinepoolmachine_owner`
+  - `capi_azuremachinepoolmachine_status_conditions`
+  - `capi_azuremachinepoolmachine_status_image_info`
+  - `capi_azuremachinepoolmachine_status_latest_model_applied`
+  - `capi_azuremachinepoolmachine_status_ready`
+  - `capi_azuremachinepoolmachine_status_version`
+
 ## [1.2.0] - 2023-01-09
 
 ### Add

--- a/helm/cluster-api-monitoring/configuration/capi_azurecluster.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_azurecluster.yaml
@@ -1,0 +1,97 @@
+labelsFromPath:
+  cluster_name:
+    - metadata
+    - ownerReferences
+    - "[kind=Cluster]"
+    - name
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
+metrics:
+  - name: annotation_paused
+    help: Whether the azurecluster is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: status_conditions
+    help: The conditions of an azurecluster.
+    each:
+      type: StateSet
+      stateSet:
+        path:
+          - status
+          - conditions
+        list:
+          - "True"
+          - "False"
+          - "Unknown"
+        valueFrom:
+          - status
+        labelName: status
+        labelsFromPath:
+          type: [type]
+  - name: info
+    help: Information about an azurecluster.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          location:
+            - spec
+            - location
+          control_plane_endpoint_ip:
+            - spec
+            - controlPlaneEndpoint
+            - host
+          control_plane_endpoint_port:
+            - spec
+            - controlPlaneEndpoint
+            - port
+          resource_group:
+            - spec
+            - resourceGroup
+  - name: status_ready
+    help: Information if the provider resource is ready.
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - ready
+  - name: created
+    help: Unix creation timestamp.
+    each:
+      gauge:
+        path:
+          - metadata
+          - creationTimestamp
+      type: Gauge
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_azuremachine.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_azuremachine.yaml
@@ -1,0 +1,107 @@
+labelsFromPath:
+  cluster_name:
+    - metadata
+    - labels
+    - cluster.x-k8s.io/cluster-name
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
+metrics:
+  - name: annotation_paused
+    help: Whether the azuremachine is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: status_conditions
+    help: The conditions of an azuremachine.
+    each:
+      type: StateSet
+      stateSet:
+        path:
+          - status
+          - conditions
+        list:
+          - "True"
+          - "False"
+          - "Unknown"
+        valueFrom:
+          - status
+        labelName: status
+        labelsFromPath:
+          type: [type]
+  - name: info
+    help: Information about an azuremachine.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          subnet:
+            - spec
+            - subnetName
+          vm_size:
+            - spec
+            - vmSize
+          os_disk_size:
+            - spec
+            - osDisk
+            - diskSizeGB
+  - name: status_addresses
+    help: Information about azuremachine network addresses.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          internal_dns:
+            - "[type=InternalDNS]"
+            - address
+          internal_ip:
+            - "[type=InternalIP]"
+            - address
+        path:
+          - status
+          - addresses
+  - name: status_ready
+    help: Information if the provider resource is ready.
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - ready
+  - name: created
+    help: Unix creation timestamp.
+    each:
+      gauge:
+        path:
+          - metadata
+          - creationTimestamp
+      type: Gauge
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_azuremachinepool.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_azuremachinepool.yaml
@@ -1,0 +1,155 @@
+labelsFromPath:
+  cluster_name:
+    - metadata
+    - labels
+    - cluster.x-k8s.io/cluster-name
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
+metrics:
+  - name: annotation_paused
+    help: Whether the azuremachine is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: status_conditions
+    help: The conditions of an azuremachine.
+    each:
+      type: StateSet
+      stateSet:
+        path:
+          - status
+          - conditions
+        list:
+          - "True"
+          - "False"
+          - "Unknown"
+        valueFrom:
+          - status
+        labelName: status
+        labelsFromPath:
+          type: [type]
+  - name: info
+    help: Information about an azuremachinepool.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          location:
+            - spec
+            - location
+          subnet:
+            - spec
+            - template
+            - spec
+            - subnetName
+          vm_size:
+            - spec
+            - template
+            - spec
+            - vmSize
+          os_disk_size:
+            - spec
+            - template
+            - spec
+            - osDisk
+            - diskSizeGB
+  - name: status_addresses
+    help: Information about azuremachine network addresses.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          internal_dns:
+            - "[type=InternalDNS]"
+            - address
+          internal_ip:
+            - "[type=InternalIP]"
+            - address
+        path:
+          - status
+          - addresses
+  - name: status_ready
+    help: Information if the provider resource is ready.
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - ready
+  - name: status_replicas
+    help: The number of replicas per azuremachinepool.
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - replicas
+        nilIsZero: true
+  - name: status_image_info
+    help: Information about azuremachinepool image.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          offer:
+            - marketplace
+            - offer
+          publisher:
+            - marketplace
+            - publisher
+          sku:
+            - marketplace
+            - sku
+          version:
+            - marketplace
+            - version
+        path:
+          - status
+          - image
+  - name: status_image_info
+    help: Information about azuremachinepool provisioning state.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          provisioning_state:
+            - status
+            - provisioningState
+  - name: created
+    help: Unix creation timestamp.
+    each:
+      gauge:
+        path:
+          - metadata
+          - creationTimestamp
+      type: Gauge
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_azuremachinepoolmachine.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_azuremachinepoolmachine.yaml
@@ -1,0 +1,114 @@
+labelsFromPath:
+  cluster_name:
+    - metadata
+    - labels
+    - cluster.x-k8s.io/cluster-name
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
+metrics:
+  - name: annotation_paused
+    help: Whether the azuremachinepoolmachine is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
+  - name: status_conditions
+    help: The conditions of an azuremachinepoolmachine.
+    each:
+      type: StateSet
+      stateSet:
+        path:
+          - status
+          - conditions
+        list:
+          - "True"
+          - "False"
+          - "Unknown"
+        valueFrom:
+          - status
+        labelName: status
+        labelsFromPath:
+          type: [type]
+  - name: status_ready
+    help: Information if the provider resource is ready.
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - ready
+  - name: status_latest_model_applied
+    help: Information if the desired VMSS model is applied.
+    each:
+      type: Gauge
+      gauge:
+        path:
+          - status
+          - latestModelApplied
+  - name: status_image_info
+    help: Information about azuremachinepoolmachine image.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          offer:
+            - marketplace
+            - offer
+          publisher:
+            - marketplace
+            - publisher
+          sku:
+            - marketplace
+            - sku
+          version:
+            - marketplace
+            - version
+        path:
+          - status
+          - image
+  - name: status_version
+    help: Version information about azuremachinepoolmachine.
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          provisioning_state:
+            - status
+            - version
+  - name: created
+    help: Unix creation timestamp.
+    each:
+      gauge:
+        path:
+          - metadata
+          - creationTimestamp
+      type: Gauge
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info

--- a/helm/cluster-api-monitoring/templates/podmonitor.yaml
+++ b/helm/cluster-api-monitoring/templates/podmonitor.yaml
@@ -10,6 +10,9 @@ spec:
     - {{.Release.Namespace}}
   podMetricsEndpoints:
   - targetPort: 8080
+    relabelings:
+    - action: labeldrop
+      regex: 'uid'
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

PR brings the following new metrics from `cluster-api-provider-azure` CRs:

```
capi_azurecluster_annotation_paused
capi_azurecluster_created
capi_azurecluster_info
capi_azurecluster_owner
capi_azurecluster_status_conditions
capi_azurecluster_status_ready
capi_azuremachine_annotation_paused
capi_azuremachine_created
capi_azuremachine_info
capi_azuremachine_owner
capi_azuremachine_status_addresses
capi_azuremachine_status_conditions
capi_azuremachine_status_ready
capi_azuremachinepool_annotation_paused
capi_azuremachinepool_created
capi_azuremachinepool_info
capi_azuremachinepool_owner
capi_azuremachinepool_status_addresses
capi_azuremachinepool_status_conditions
capi_azuremachinepool_status_image_info
capi_azuremachinepool_status_ready
capi_azuremachinepool_status_replicas
capi_azuremachinepoolmachine_annotation_paused
capi_azuremachinepoolmachine_created
capi_azuremachinepoolmachine_owner
capi_azuremachinepoolmachine_status_conditions
capi_azuremachinepoolmachine_status_image_info
capi_azuremachinepoolmachine_status_latest_model_applied
capi_azuremachinepoolmachine_status_ready
capi_azuremachinepoolmachine_status_version
```

# `capi_azurecluster_status_conditions`
```
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="LoadBalancersReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="NATGatewaysReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="NetworkInfrastructureReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="PublicIPsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="Ready",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="ResourceGroupReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="RouteTablesReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="SecurityGroupsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="SubnetsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="False",type="VNetReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="LoadBalancersReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="NATGatewaysReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="NetworkInfrastructureReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="PublicIPsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="Ready",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="ResourceGroupReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="RouteTablesReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="SecurityGroupsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="SubnetsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="True",type="VNetReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="LoadBalancersReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="NATGatewaysReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="NetworkInfrastructureReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="PublicIPsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="Ready",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="ResourceGroupReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="RouteTablesReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="SecurityGroupsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="SubnetsReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
capi_azurecluster_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",status="Unknown",type="VNetReady",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 0
```

# `capi_azurecluster_info`
```
capi_azurecluster_info{cluster_name="marioc1",control_plane_endpoint_ip="marioc1-d1107536.westeurope.cloudapp.azure.com",control_plane_endpoint_port="6443",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",location="westeurope",name="marioc1",namespace="org-multi-project",resource_group="marioc1",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
```

# `capi_azurecluster_status_ready`
```
capi_azurecluster_status_ready{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
```

# `capi_azurecluster_created`
```
capi_azurecluster_created{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1.672752467e+09
```

# `capi_azurecluster_owner`
```
capi_azurecluster_owner{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureCluster",name="marioc1",namespace="org-multi-project",owner_is_controller="true",owner_kind="Cluster",owner_name="marioc1",owner_uid="dd5ed135-1a9a-4687-97da-8133af09cf13",uid="4bd1e014-07b2-4680-8867-51667dc03395",version="v1beta1"} 1
```

# `capi_azuremachinepoolmachine_status_conditions`
```
capi_azuremachinepoolmachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",status="False",type="NodeHealthy",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 0
capi_azuremachinepoolmachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",status="False",type="Ready",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 0
capi_azuremachinepoolmachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",status="True",type="NodeHealthy",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 1
capi_azuremachinepoolmachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",status="True",type="Ready",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 1
capi_azuremachinepoolmachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",status="Unknown",type="NodeHealthy",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 0
capi_azuremachinepoolmachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",status="Unknown",type="Ready",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 0
capi_azuremachinepoolmachine_status_ready{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 1
capi_azuremachinepoolmachine_status_latest_model_applied{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 1
capi_azuremachinepoolmachine_status_version{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",provisioning_state="v1.24.8",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 1
capi_azuremachinepoolmachine_created{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 1.672752766e+09
capi_azuremachinepoolmachine_owner{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePoolMachine",name="marioc1-def00-3830f64e-0",namespace="org-multi-project",owner_kind="AzureMachinePool",owner_name="marioc1-def00-3830f64e",owner_uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",uid="a9ff444d-f73d-4d58-b81a-9a7d72bead8f",version="v1beta1"} 1
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="False",type="BootstrapSucceeded",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="False",type="Ready",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="False",type="ScaleSetDesiredReplicas",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="False",type="ScaleSetModelUpdated",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="False",type="ScaleSetRunning",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="True",type="BootstrapSucceeded",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="True",type="Ready",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="True",type="ScaleSetDesiredReplicas",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="True",type="ScaleSetModelUpdated",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="True",type="ScaleSetRunning",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="Unknown",type="BootstrapSucceeded",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="Unknown",type="Ready",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="Unknown",type="ScaleSetDesiredReplicas",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="Unknown",type="ScaleSetModelUpdated",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
capi_azuremachinepool_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",status="Unknown",type="ScaleSetRunning",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 0
```

# `capi_azuremachinepool_info`
```
capi_azuremachinepool_info{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",location="westeurope",name="marioc1-def00-3830f64e",namespace="org-multi-project",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
```

# `capi_azuremachinepool_status_ready`
```
capi_azuremachinepool_status_ready{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
```

# `capi_azuremachinepool_status_replicas`
```
capi_azuremachinepool_status_replicas{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
```

# `capi_azuremachinepool_status_image_info`
```
capi_azuremachinepool_status_image_info{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",offer="capi",publisher="cncf-upstream",sku="ubuntu-2004-gen1",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="124.8.20221129"} 1
```

# `capi_azuremachinepool_created`
```
capi_azuremachinepool_created{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1.672752467e+09
```

# `capi_azuremachinepool_owner`
```
capi_azuremachinepool_owner{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachinePool",name="marioc1-def00-3830f64e",namespace="org-multi-project",owner_is_controller="true",owner_kind="MachinePool",owner_name="marioc1-def00",owner_uid="a0265b96-6b70-4a9a-b72b-9a4c2d3587d3",uid="c7690fff-dad1-431e-ab63-7ae18f0bdc9e",version="v1beta1"} 1
```

# `capi_azuremachine_status_conditions`
```
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="False",type="BootstrapSucceeded",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="False",type="DisksReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="False",type="InboundNATRulesReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="False",type="NetworkInterfacesReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="False",type="Ready",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="False",type="VMRunning",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="True",type="BootstrapSucceeded",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="True",type="DisksReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="True",type="InboundNATRulesReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="True",type="NetworkInterfacesReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="True",type="Ready",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="True",type="VMRunning",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="Unknown",type="BootstrapSucceeded",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="Unknown",type="DisksReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="Unknown",type="InboundNATRulesReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="Unknown",type="NetworkInterfacesReady",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="Unknown",type="Ready",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
capi_azuremachine_status_conditions{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",status="Unknown",type="VMRunning",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 0
```

# `capi_azuremachine_info`
```
capi_azuremachine_info{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",os_disk_size="50",subnet="control-plane-subnet",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1",vm_size="Standard_D4s_v3"} 1
```

# `capi_azuremachine_status_ready`
```
capi_azuremachine_status_ready{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1
```

# `capi_azuremachine_created`
```
capi_azuremachine_created{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1.672752573e+09
```

# `capi_azuremachine_owner`
```
capi_azuremachine_owner{cluster_name="marioc1",group="infrastructure.cluster.x-k8s.io",kind="AzureMachine",name="marioc1-control-plane-a72bcf8f-lksgv",namespace="org-multi-project",owner_is_controller="true",owner_kind="Machine",owner_name="marioc1-jjxd5",owner_uid="b66987fc-51b6-4bed-bfbe-74e3537b6d2a",uid="cb65baeb-eb64-4257-a8d5-c69b65467aed",version="v1beta1"} 1
```



<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
