### PR TITLE
fix psp seccomp profile

### DIFF
--- a/helm/cluster-api-monitoring/templates/podsecuritypolicy.yaml
+++ b/helm/cluster-api-monitoring/templates/podsecuritypolicy.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "name" . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    ## Added to allow runtime-default seccomp profile
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
   privileged: false
   fsGroup:


### PR DESCRIPTION

This PR:

- allow the runtime/default seccomp profile in the PSP

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
