### PR TITLE
push to capz app collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,3 +71,17 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: capz-app-collection
+          context: "architect"
+          app_name: "cluster-api-monitoring"
+          app_collection_repo: "capz-app-collection"
+          requires:
+            - push-to-control-plane-app-catalog
+          # Trigger job on git tag.
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Add
+
+- push to `capz-app-collection`
+
 ## [1.7.0] - 2023-06-15
 
 ### Add


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

app is currently only pushed to `capa`, `vsphere` and `cloud-director` app collection. `capz` is missing

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] metric name change doesn't affect existing alerts
