### PR TITLE
Enable CiliumNetworkPolicy by default and add metrics port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable CiliumNetworkPolicy by default and add metrics port.
+
 ## [1.8.1] - 2024-01-18
 
 ### Added

--- a/helm/cluster-api-monitoring/templates/ciliumnetworkpolicy.yaml
+++ b/helm/cluster-api-monitoring/templates/ciliumnetworkpolicy.yaml
@@ -11,4 +11,10 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+  ingress:
+    - fromEntities:
+      - cluster
+      toPorts:
+      - ports:
+          - port: "8080"
 {{- end }}

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-monitoring
 serviceType: managed
 
 ciliumNetworkPolicy:
-  enabled: false
+  enabled: true
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/29581

This PR:

- Enable CiliumNetworkPolicy by default and add metrics port

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
