### PR TITLE
Add Flux resource_info metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Flux `resouce_info` metrics.
+
 ## [1.11.0] - 2024-04-09
 
 ### Changed

--- a/helm/cluster-api-monitoring/configuration/flux_alert.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_alert.yaml
@@ -1,0 +1,11 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux Alert resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      suspended: [ spec, suspend ]

--- a/helm/cluster-api-monitoring/configuration/flux_bucket.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_bucket.yaml
@@ -1,0 +1,15 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux Bucket resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      revision: [ status, artifact, revision ]
+      endpoint: [ spec, endpoint ]
+      bucket_name: [ spec, bucketName ]

--- a/helm/cluster-api-monitoring/configuration/flux_gitrepository.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_gitrepository.yaml
@@ -1,0 +1,14 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux GitRepository resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      revision: [ status, artifact, revision ]
+      url: [ spec, url ]

--- a/helm/cluster-api-monitoring/configuration/flux_helmchart.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_helmchart.yaml
@@ -1,0 +1,15 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux HelmChart resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      revision: [ status, artifact, revision ]
+      chart_name: [ spec, chart ]
+      chart_version: [ spec, version ]

--- a/helm/cluster-api-monitoring/configuration/flux_helmrelease.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_helmrelease.yaml
@@ -1,0 +1,15 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux HelmRelease resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      revision: [ status, lastAppliedRevision ]
+      chart_name: [ spec, chart, spec, chart ]
+      chart_source_name: [ spec, chart, spec, sourceRef, name ]

--- a/helm/cluster-api-monitoring/configuration/flux_helmrepository.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_helmrepository.yaml
@@ -1,0 +1,14 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux HelmRepository resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      revision: [ status, artifact, revision ]
+      url: [ spec, url ]

--- a/helm/cluster-api-monitoring/configuration/flux_imagepolicy.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_imagepolicy.yaml
@@ -1,0 +1,13 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux ImagePolicy resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      source_name: [ spec, imageRepositoryRef, name ]

--- a/helm/cluster-api-monitoring/configuration/flux_imagerepository.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_imagerepository.yaml
@@ -1,0 +1,13 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux ImageRepository resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      image: [ spec, image ]

--- a/helm/cluster-api-monitoring/configuration/flux_imageupdateautomation.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_imageupdateautomation.yaml
@@ -1,0 +1,13 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux ImageUpdateAutomation resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      source_name: [ spec, sourceRef, name ]

--- a/helm/cluster-api-monitoring/configuration/flux_kustomization.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_kustomization.yaml
@@ -1,0 +1,14 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux Kustomization resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      revision: [ status, lastAppliedRevision ]
+      source_name: [ spec, sourceRef, name ]

--- a/helm/cluster-api-monitoring/configuration/flux_ocirepository.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_ocirepository.yaml
@@ -1,0 +1,14 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux OCIRepository resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      revision: [ status, artifact, revision ]
+      url: [ spec, url ]

--- a/helm/cluster-api-monitoring/configuration/flux_provider.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_provider.yaml
@@ -1,0 +1,11 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux Provider resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      suspended: [ spec, suspend ]

--- a/helm/cluster-api-monitoring/configuration/flux_receiver.yaml
+++ b/helm/cluster-api-monitoring/configuration/flux_receiver.yaml
@@ -1,0 +1,13 @@
+metrics:
+  - name: "resource_info"
+    help: "The current state of a Flux Receiver resource."
+    each:
+      type: Info
+      info:
+        labelsFromPath:
+          name: [ metadata, name ]
+    labelsFromPath:
+      exported_namespace: [ metadata, namespace ]
+      ready: [ status, conditions, "[type=Ready]", status ]
+      suspended: [ spec, suspend ]
+      webhook_path: [ status, webhookPath ]


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/29962

Related to: https://github.com/giantswarm/shared-configs/pull/55

Taken from: https://github.com/fluxcd/flux2-monitoring-example/blob/fbf131257de3a63e41ab7d86a28ac5a4bcc9a08b/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] metric name change doesn't affect existing alerts
