### PR TITLE
Monitor CRD versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CRD metric `capi_crd_info` labeled with the available versions.
+
 ## [1.12.0] - 2024-05-08
 
 ### Added

--- a/helm/cluster-api-monitoring/configuration/capi_crd.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_crd.yaml
@@ -1,0 +1,11 @@
+labelsFromPath:
+  resource_name: [metadata, name]
+metrics:
+  - name: "info"
+    help: "CAPI CRD Info"
+    each:
+      type: Info
+      info:
+        path: [spec, versions]
+        labelsFromPath:
+          version: [name]


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

Towards https://github.com/giantswarm/roadmap/issues/3344
This adds a new metric containing CRD name and version. We want to use this to keep track of available CAPA CRD versions installed on MCs.
I wanted to filter out only the CRDs with the `infrastructure.cluster.x-k8s.io` group, but I couldn't make it work. The [kube-state-metrics docs]() suggest that this should be possible. If you have any suggestions I'm open to trying out something different, otherwise the filtering will have to happen later.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
