### PR TITLE
Include release version in CAPI cluster metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Include `release_version` label in capi_cluster_XXX metrics
+
 ## [1.14.0] - 2024-05-29
 
 ### Added
@@ -64,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Cleanup comments from `README.md` as all mentioned changes/PRs got merged and released in upstream `KSM`. 
+- Cleanup comments from `README.md` as all mentioned changes/PRs got merged and released in upstream `KSM`.
 
 ## [1.7.1] - 2023-06-15
 
@@ -96,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `infrastructure_reference_kind`
   - `infrastructure_reference_name`
   - `control_plane_name` if the machine is a control-plane machine
-  
+
 ## [1.6.0] - 2023-05-31
 
 ### Add

--- a/helm/cluster-api-monitoring/configuration/capi_cluster.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_cluster.yaml
@@ -8,6 +8,10 @@ labelsFromPath:
   uid:
     - metadata
     - uid
+  release_version:
+    - metadata
+    - labels
+    - release.giantswarm.io/version
 metrics:
   - name: info
     help: Information about a cluster.


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- includes a `release_version` label on all `capi_cluster_xxx` metrics that uses the `release.giantswarm.io/version` label value from the Cluster CR

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
