### PR TITLE
Add metrics for karpenter machines and KubeadmConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add karpenter machines monitoring.
+
 ## [1.15.0] - 2024-10-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add karpenter machines monitoring.
+- Add metrics for karpenter machines.
+- Add metrics for `Kubeadmconfig` CRs.
 
 ## [1.15.0] - 2024-10-25
 

--- a/helm/cluster-api-monitoring/configuration/capi_kubeadmconfig.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_kubeadmconfig.yaml
@@ -18,6 +18,7 @@ metrics:
     each:
       stateSet:
         labelName: status
+        labelFromKey: reason
         labelsFromPath:
           type:
             - type

--- a/helm/cluster-api-monitoring/configuration/capi_kubeadmconfig.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_kubeadmconfig.yaml
@@ -13,18 +13,46 @@ labelsFromPath:
     - metadata
     - uid
 metrics:
+  - name: info
+    help: Information about a kubeadmconfig.
+    each:
+      info:
+        # TODO: added metadata.name even it's already defined above as the metric doesn't work with empty labelsFromPath.
+        labelsFromPath:
+          name:
+            - metadata
+            - name
+      type: Info
+  - name: created
+    help: Unix creation timestamp.
+    each:
+      gauge:
+        path:
+          - metadata
+          - creationTimestamp
+      type: Gauge
+  - name: annotation_paused
+    help: Whether the kubeadmconfig is paused and any of its resources will not be processed by the controllers.
+    each:
+      info:
+        path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        labelsFromPath:
+          paused_value: []
+      type: Info
   - name: status_condition
     help: The condition of a kubeadmconfig.
     each:
       stateSet:
         labelName: status
-        labelFromKey: reason
         labelsFromPath:
           type:
             - type
         list:
-          - "True"
-          - "False"
+          - 'True'
+          - 'False'
           - Unknown
         path:
           - status
@@ -47,3 +75,20 @@ metrics:
         valueFrom:
           - lastTransitionTime
       type: Gauge
+  - name: owner
+    help: Owner references.
+    each:
+      info:
+        labelsFromPath:
+          owner_is_controller:
+            - controller
+          owner_kind:
+            - kind
+          owner_name:
+            - name
+          owner_uid:
+            - uid
+        path:
+          - metadata
+          - ownerReferences
+      type: Info

--- a/helm/cluster-api-monitoring/configuration/capi_kubeadmconfig.yaml
+++ b/helm/cluster-api-monitoring/configuration/capi_kubeadmconfig.yaml
@@ -1,0 +1,48 @@
+labelsFromPath:
+  cluster_name:
+    - metadata
+    - labels
+    - cluster.x-k8s.io/cluster-name
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
+metrics:
+  - name: status_condition
+    help: The condition of a kubeadmconfig.
+    each:
+      stateSet:
+        labelName: status
+        labelsFromPath:
+          type:
+            - type
+        list:
+          - "True"
+          - "False"
+          - Unknown
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - status
+      type: StateSet
+  - name: status_condition_last_transition_time
+    help: The condition last transition time of a kubeadmconfig.
+    each:
+      gauge:
+        labelsFromPath:
+          type:
+            - type
+          status:
+            - status
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - lastTransitionTime
+      type: Gauge

--- a/helm/cluster-api-monitoring/configuration/karpenter_machine.yaml
+++ b/helm/cluster-api-monitoring/configuration/karpenter_machine.yaml
@@ -1,0 +1,81 @@
+labelsFromPath:
+  cluster_name:
+    - metadata
+    - labels
+    - cluster
+  name:
+    - metadata
+    - name
+  namespace:
+    - metadata
+    - namespace
+  uid:
+    - metadata
+    - uid
+metrics:
+  - name: info
+    help: Information about a karpenter machine.
+    each:
+      info:
+        labelsFromPath:
+          region:
+            - metadata
+            - labels
+            - topology.kubernetes.io/region
+          availability_zone:
+            - metadata
+            - labels
+            - topology.kubernetes.io/zone
+          nodepool_name:
+            - metadata
+            - labels
+            - nodepool
+          instance_type:
+            - metadata
+            - labels
+            - node.kubernetes.io/instance-type
+          provisioner_name:
+            - metadata
+            - labels
+            - karpenter.sh/provisioner-name
+          capacity_type:
+            - metadata
+            - labels
+            - karpenter.sh/capacity-type
+          node_name:
+            - status
+            - nodeName
+      type: Info
+  - name: status_condition
+    help: The condition of a machine.
+    each:
+      stateSet:
+        labelName: status
+        labelsFromPath:
+          type:
+            - type
+        list:
+          - "True"
+          - "False"
+          - Unknown
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - status
+      type: StateSet
+  - name: status_condition_last_transition_time
+    help: The condition last transition time of a machine.
+    each:
+      gauge:
+        labelsFromPath:
+          type:
+            - type
+          status:
+            - status
+        path:
+          - status
+          - conditions
+        valueFrom:
+          - lastTransitionTime
+      type: Gauge


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32111

[We need this version bump](https://github.com/giantswarm/cluster-api-monitoring-app/pull/126) to get the karpenter machine metrics working, because version 2.7.0 was affected [by this bug](https://github.com/kubernetes/kube-state-metrics/issues/2015), which prevents the app from generating metrics from two CRDs with the same name, and we have CAPI Machines and karpenter Machines.

### Checklist

- [X] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] metric name change doesn't affect existing alerts
