### PR TITLE
Bump kube-state-metrics to 2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `kube-state-metrics` to `v2.9.2`.
+
 ## [1.15.0] - 2024-10-25
 
 ### Added

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -15,7 +15,7 @@ project:
 image:
   registry: gsoci.azurecr.io
   name: giantswarm/kube-state-metrics
-  tag: v2.8.1
+  tag: v2.9.2
   pullPolicy: IfNotPresent
 
 podSecurityContext:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32111

The version defined in this app was being overwritten by [our configuration repository](https://github.com/giantswarm/shared-configs/blob/main/default/apps/cluster-api-monitoring/configmap-values.yaml.template#L3-L4). The tag used in our config repository [is this one from upstream](https://github.com/kubernetes/kube-state-metrics/commit/49af6b3945a071ec63de8b2cadaf4d5eec1bdd57), which was merged [on this PR](https://github.com/kubernetes/kube-state-metrics/issues/1973) (submitted by a GiantSwarm employee), and then released in v2.9.0. 

### Checklist

- [X] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] metric name change doesn't affect existing alerts
