### PR TITLE
Fix RBAC permissions for customresourcedefinitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RBAC permissions for `apiextensions.k8s.io` group.
+
 ## [1.16.0] - 2024-11-28
 
 ### Added

--- a/helm/cluster-api-monitoring/Chart.yaml
+++ b/helm/cluster-api-monitoring/Chart.yaml
@@ -5,5 +5,5 @@ home: https://github.com/giantswarm/cluster-api-monitoring
 version: "[[ .Version ]]"
 appVersion: "[[ .AppVersion ]]"
 annotations:
-  application.giantswarm.io/team: rocket
+  application.giantswarm.io/team: tenet
   config.giantswarm.io/version: 0.1.0

--- a/helm/cluster-api-monitoring/templates/clusterrole.yaml
+++ b/helm/cluster-api-monitoring/templates/clusterrole.yaml
@@ -57,3 +57,11 @@ Result will look like:
       - list
       - watch
 {{- end }}
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
I noticed in a couple of MC's `cluster-api-monitoring` is silenty
"failing".

Fixes:

```
E0107 11:16:34.252569       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.5/tools/cache/reflector.go:169: Failed to watch *unstructured.Unstructured: failed to list *unstructured.Unstructured: customresourcedefinitions.apiextensions.k8s.io is forbidden: User "system:serviceaccount:giantswarm:cluster-api-monitoring" cannot list resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

I didn't add this into the configuration, because it doesn't make sense
to included in the shared configuration file.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] metric name change doesn't affect existing alerts