### PR TITLE
Increase default memory resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set default memory resources to `200Mi`.
+
 ## [1.16.1] - 2025-01-07
 
 ### Fixed

--- a/helm/cluster-api-monitoring/values.yaml
+++ b/helm/cluster-api-monitoring/values.yaml
@@ -36,9 +36,9 @@ containerSecurityContext:
 
 resources:
   limits:
-    memory: 100Mi
+    memory: 200Mi
   requests:
-    memory: 100Mi
+    memory: 200Mi
 # List of CRs to monitor
 # This list is defined in the config repo per installation and will be merged together with
 # default values from the config repo.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32663

I checked a couple of clusters to find a sweet spot the actual usage
when starting before the VPA kicks in.

This should be a good start setting.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] metric name change doesn't affect existing alerts