### PR TITLE
Enhancing Flux-related metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't use CRs kind in the Flux-related metrics names.
+- Set the `cluster_name` as a common metric label for the Flux-related metrics.
+
 ## [1.17.0] - 2025-04-04
 
 ### Changed

--- a/helm/cluster-api-monitoring/templates/configmap.yaml
+++ b/helm/cluster-api-monitoring/templates/configmap.yaml
@@ -15,8 +15,14 @@ data:
       - groupVersionKind:
           group: {{ $val.group }}
           kind: {{ $val.kind }}
-          version: {{ $val.version }}
+          version: {{ $val.version | quote }}
+        {{- if eq $componentKey "flux" }}
+        commonLabels:
+          cluster_name: "{{ $.Values.managementCluster.name }}"
+        metricNamePrefix: "gotk"
+        {{- else }}
         metricNamePrefix: {{(printf "%s_%s"  $componentKey $key)}}
+        {{- end }}
 {{ $.Files.Get (printf "configuration/%s_%s.yaml" $componentKey $key) | indent 8}}
     {{ end }}
   {{- end }}


### PR DESCRIPTION
This PR changes Flux metrics names from `flux_<kind>_resource_info` to `gotk_resource_info`, the respective kind can be found in the `customresource_kind` label. 

It also adds the `cluster_name` as a common label based on the values.yaml-provided cluster name, so that Flux metrics carry the right `cluster_id` and `cluster_type` at the end, for as of now these values equal to the resource name and `workload_cluster` respectively.

Flux-unrelated metrics are not affected by this change.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] metric name change doesn't affect existing alerts
